### PR TITLE
fix(peer-deps): widen react peer range to >=16.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "types": "dist/index.d.ts",
   "peerDependencies": {
-    "react": "19.2.7"
+    "react": ">=16.8.0"
   },
   "devDependencies": {
     "@commitlint/cli": "21.0.2",

--- a/renovate.json
+++ b/renovate.json
@@ -14,6 +14,10 @@
       "enabled": false
     },
     {
+      "matchDepTypes": ["peerDependencies"],
+      "enabled": false
+    },
+    {
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "non-major dependencies",
       "automerge": true,


### PR DESCRIPTION
`peerDependencies.react` was pinned to `19.2.7`, which blocks every consumer not on that exact patch.

The hook only imports `useState`, so `>=16.8.0` is the real requirement.

Renovate's global `rangeStrategy: "pin"` would just re-pin it, so `peerDependencies` is now excluded from Renovate. devDependencies stay pinned — tests still run against React 19.