### PR TITLE
docs: point the demo link at laigary.com/labs/use-tw-zipcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![npm](https://img.shields.io/npm/v/use-tw-zipcode)](https://www.npmjs.com/package/use-tw-zipcode)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 
+**[線上 Demo](https://laigary.com/labs/use-tw-zipcode)** — 直接在瀏覽器裡選縣市，看郵遞區號跳出來。
+
 ## Intro 簡介
 
 可以簡單地製作台灣縣市、行政區下拉式選單，並取得郵遞區號。本套件只處理邏輯的部分，所以可以很簡單地應用於各種 CSS 版型。
@@ -47,8 +49,8 @@ export default function App() {
 }
 ```
 
-## Live Demo
+## Live Demo 線上 Demo
 
-[https://use-tw-zipcode.vercel.app/](https://use-tw-zipcode.vercel.app/)
+[https://laigary.com/labs/use-tw-zipcode](https://laigary.com/labs/use-tw-zipcode)
 
-Demo Source Code: [https://github.com/imgarylai/use-tw-zipcode-vercel](https://github.com/imgarylai/use-tw-zipcode-vercel)
+The demo runs the published package in the browser; the interactive options mirror the hook's own API.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "React hook for getting Taiwan zip code.",
   "license": "MIT",
   "author": "Gary Lai <garylai1990@gmail.com>",
-  "homepage": "https://github.com/imgarylai/use-tw-zipcode#readme",
+  "homepage": "https://laigary.com/labs/use-tw-zipcode",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/imgarylai/use-tw-zipcode"


### PR DESCRIPTION
Consolidates the demo for this package onto <https://laigary.com/labs/use-tw-zipcode>, alongside the other three.

**Why:** the four packages each had their demo somewhere different — two Vercel apps and two typedoc sites — so there was no shared experience, and nothing typechecked the demo against the package. The new pages install the published package and are built in the site's CI, so a breaking release fails the build instead of leaving a demo that quietly lies.

**Changes:** README demo link (and `README.en.md` where present) plus `package.json` `homepage`. The homepage field reaches npm on the next release; `docs:` does not trigger one on its own.

⚠️ **Do not merge until laigary.com/labs is deployed** — the link 404s until then.